### PR TITLE
16 loading wallpapers from storage is slow

### DIFF
--- a/src/html/modals/background-settings.html
+++ b/src/html/modals/background-settings.html
@@ -11,9 +11,7 @@
   <div>
     <p>
       <b>Disclaimer: </b> <br>
-      I am aware of the issue with wallpapers sometimes not being saved. <br>
-      If you encounter this issue please help me and provide more info on <a class="link"
-        href="https://github.com/Metal-spoon/win95-newtab/issues/5">Github</a>
+      Large images can be quite slow to load, please take that into account when choosing wallpapers!
     </p>
   </div>
 </div>

--- a/src/js/components/wallpaper-component.js
+++ b/src/js/components/wallpaper-component.js
@@ -1,5 +1,8 @@
 import { Wallpaper } from '../models/wallpaper.js'
 
+let selectedWallpaper
+const assetPath = '/assets/img/bg/'
+
 export function init () {
   chrome.storage.local.get(['wallpapers', 'randomWallpaper'], (result) => {
     let wallpapers = result.wallpapers
@@ -15,27 +18,33 @@ export function init () {
       randomWallpaper = true
       chrome.storage.local.set({ randomWallpaper })
     }
-    const selectedWallpaper = selectWallpaper(wallpapers, randomWallpaper)
+    selectedWallpaper = selectWallpaper(wallpapers, randomWallpaper)
     updateDOM(selectedWallpaper)
   })
 }
 
 function selectWallpaper (wallpapers, isRandom) {
-  let selectedWallpaper
+  let wallpaper
   if (isRandom) {
     const enabledWallpapers = wallpapers.filter((x) => x.isEnabled === true)
     const index = Math.floor(Math.random() * enabledWallpapers.length)
-    selectedWallpaper = enabledWallpapers[index]
+    wallpaper = enabledWallpapers[index]
   } else {
-    selectedWallpaper = wallpapers.find((x) => x.isEnabled === true)
+    wallpaper = wallpapers.find((x) => x.isEnabled === true)
   }
 
-  return selectedWallpaper
+  return wallpaper
 }
 
-function updateDOM (wallpaper) {
-  const cssValue = wallpaper.imageData
-    ? 'url(' + wallpaper.imageData + ')'
-    : 'url(/assets/img/bg/' + wallpaper.fileName + ')'
-  $('.background').css('background-image', cssValue)
+export function updateDOM () {
+  let cssValue
+  if (selectedWallpaper.isDefault) {
+    cssValue = 'url(' + assetPath + selectedWallpaper.fileName + ')'
+    $('.background').css('background-image', cssValue)
+  } else {
+    chrome.storage.local.get(selectedWallpaper.key, (result) => {
+      cssValue = 'url(' + result[selectedWallpaper.key] + ')'
+      $('.background').css('background-image', cssValue)
+    })
+  }
 }

--- a/src/js/models/wallpaper.js
+++ b/src/js/models/wallpaper.js
@@ -4,7 +4,6 @@ export class Wallpaper {
     this.isDefault = isDefault
     this.isEnabled = isEnabled
     this.imageData = imageData
-    this.id =
-      id != null ? id : JSON.parse(localStorage.getItem('wallpapers')).length
+    this.id = id
   }
 }

--- a/src/js/models/wallpaper.js
+++ b/src/js/models/wallpaper.js
@@ -1,9 +1,9 @@
 export class Wallpaper {
-  constructor (fileName, isDefault, isEnabled, imageData, id) {
+  constructor (fileName, isDefault, isEnabled, key, id) {
     this.fileName = fileName
     this.isDefault = isDefault
     this.isEnabled = isEnabled
-    this.imageData = imageData
+    this.key = key
     this.id = id
   }
 }

--- a/src/js/settings/wallpaper-settings.js
+++ b/src/js/settings/wallpaper-settings.js
@@ -28,6 +28,7 @@ function bindEvents () {
 function onFileUpload (e) {
   const filereader = new FileReader()
   filereader.onload = () => {
+    const id = wallpapers.reduce((a, b) => (a.id > b.y ? a : b)).id + 1
     const data = filereader.result
     let isEnabled = true
     if (
@@ -41,7 +42,7 @@ function onFileUpload (e) {
       false,
       isEnabled,
       data,
-      null
+      id
     )
     wallpapers.push(wallpaperObject)
     const element = buildWallpaperListElement(wallpaperObject)

--- a/src/js/settings/wallpaper-settings.js
+++ b/src/js/settings/wallpaper-settings.js
@@ -1,19 +1,29 @@
 import { Wallpaper } from '../models/wallpaper.js'
 let wallpapers
 let randomWallpaper
+let imageData = {}
+const keysToDelete = []
+const keyPrefix = 'WP_'
+const assetPath = '../assets/img/bg/'
 
 export function init () {
   chrome.storage.local.get(['wallpapers', 'randomWallpaper'], (result) => {
     wallpapers = result.wallpapers
-    wallpapers.forEach((wallpaper) => {
-      const element = buildWallpaperListElement(wallpaper)
-      $('.wallpaper-list').append(element)
-    })
     randomWallpaper = result.randomWallpaper
+    const keys = wallpapers.flatMap((wallpaper) =>
+      wallpaper.key ? wallpaper.key : []
+    )
     $('#randomCheckbox')[0].checked = randomWallpaper
-    bindEvents()
-    updateWallpaperDOM()
-    $('#settings-modal').show()
+    chrome.storage.local.get(keys, (storedImageData) => {
+      imageData = storedImageData
+      wallpapers.forEach((wallpaper) => {
+        const element = buildWallpaperListElement(wallpaper)
+        $('.wallpaper-list').append(element)
+      })
+      updateWallpaperDOM()
+      bindEvents()
+      $('#settings-modal').show()
+    })
   })
 }
 
@@ -30,6 +40,8 @@ function onFileUpload (e) {
   filereader.onload = () => {
     const id = wallpapers.reduce((a, b) => (a.id > b.y ? a : b)).id + 1
     const data = filereader.result
+    const key = keyPrefix + id
+    imageData[key] = data
     let isEnabled = true
     if (
       !randomWallpaper &&
@@ -41,7 +53,7 @@ function onFileUpload (e) {
       e.target.files[0].name,
       false,
       isEnabled,
-      data,
+      key,
       id
     )
     wallpapers.push(wallpaperObject)
@@ -123,22 +135,27 @@ function toggleWallpaper (e) {
 function deleteWallpaper (e) {
   const id = Number(e.target.parentElement.children[2].innerText)
   const wallpaperIndex = wallpapers.findIndex((x) => x.id === id)
+  const wallpaper = wallpapers[wallpaperIndex]
+  keysToDelete.push(wallpaper.key)
+  delete imageData[wallpaper.key]
   wallpapers.splice(wallpaperIndex, 1)
   e.target.parentElement.parentNode.removeChild(e.target.parentElement)
   updateWallpaperDOM()
 }
 
 function buildWallpaperListElement (wallpaper) {
+  const imageSrc = wallpaper.isDefault
+    ? assetPath + wallpaper.fileName
+    : imageData[wallpaper.key]
+
   let element =
     "<li title='" +
     wallpaper.fileName +
     "' class='wallpaper-item'>" +
     "<div class='wallpaper-image-wrapper checkBoxContainer'>"
-  if (wallpaper.imageData) {
-    element = element + "<img src='" + wallpaper.imageData
-  } else {
-    element = element + "<img src='../assets/img/bg/" + wallpaper.fileName
-  }
+
+  element = element + "<img src='" + imageSrc
+
   element =
     element +
     "' width='96px' height='54px' />" +
@@ -170,5 +187,16 @@ function buildWallpaperListElement (wallpaper) {
 }
 
 export function save () {
-  chrome.storage.local.set({ wallpapers, randomWallpaper })
+  chrome.storage.local.remove(keysToDelete, () => {
+    const savedata = {
+      wallpapers,
+      randomWallpaper
+    }
+    wallpapers.forEach((wallpaper) => {
+      if (!wallpaper.isDefault) {
+        savedata[wallpaper.key] = imageData[wallpaper.key]
+      }
+    })
+    chrome.storage.local.set(savedata)
+  })
 }


### PR DESCRIPTION
Optimized by saving image data separately under it's own key.
When the page is loaded, only the image data of the chosen wallpaper gets fetched, this is way faster than what it was before.