### PR TITLE
27 settings for topsites

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -43,7 +43,7 @@
     <div class="menuItem" id="background-settings">Background settings</div>
     <div class="menuItem" id="search-settings">Search settings</div>
     <div class="menuItem" id="clock-settings">Clock settings</div>
-    <div class="menuItem" id="misc-settings">Misc. settings</div>
+    <div class="menuItem" id="shortcut-settings">Shortcut settings</div>
     <div class="divider"></div>
     <div class="menuItem" id="credits">Credits</div>
   </div>

--- a/src/html/modals/misc-settings.html
+++ b/src/html/modals/misc-settings.html
@@ -1,6 +1,0 @@
-<div id="misc-settings-modal">
-  <label class="checkBoxContainer"
-    >Use most visited instead of top sites (experimental, slow)
-    <input type="checkbox" name="usehistory"/> <span class="checkmark"></span
-  ></label>
-</div>

--- a/src/html/modals/shortcut-settings.html
+++ b/src/html/modals/shortcut-settings.html
@@ -1,0 +1,8 @@
+<div id="shortcut-settings-modal">
+  <label class="checkBoxContainer">Trim titles?
+    <input type="checkbox" name="TrimTitles" /> <span class="checkmark"></span></label>
+  <label class="checkBoxContainer">Enable outline?
+    <input type="checkbox" name="TopsiteOutlines" /> <span class="checkmark"></span></label>
+  <label class="checkBoxContainer">Retro titles?
+    <input type="checkbox" name="RetroTitles" /> <span class="checkmark"></span></label>
+</div>

--- a/src/js/components/clock-component.js
+++ b/src/js/components/clock-component.js
@@ -1,27 +1,14 @@
-import {
-  HourFormat24 as defaultHourFormat24,
-  ShowSeconds as defaultShowSeconds,
-  SetDefaultSettings
-} from '../settings/defaults.js'
-
 let HourFormat24
 let ShowSeconds
 let clockInterval
 
-export function init () {
-  chrome.storage.local.get(['HourFormat24', 'ShowSeconds'], (result) => {
-    HourFormat24 = result.HourFormat24
-    ShowSeconds = result.ShowSeconds
-    if (HourFormat24 == null || ShowSeconds == null) {
-      HourFormat24 = defaultHourFormat24
-      ShowSeconds = defaultShowSeconds
-      SetDefaultSettings()
-    }
-    clearInterval(clockInterval)
+export function init (settings) {
+  HourFormat24 = settings.HourFormat24
+  ShowSeconds = settings.ShowSeconds
+  clearInterval(clockInterval)
 
-    updateClock()
-    clockInterval = setInterval(updateClock, 1000)
-  })
+  updateClock()
+  clockInterval = setInterval(updateClock, 1000)
 }
 
 function updateClock () {

--- a/src/js/components/modal-component.js
+++ b/src/js/components/modal-component.js
@@ -2,6 +2,7 @@ import * as searchSettings from '../settings/search-settings.js'
 import * as wallpaperSettings from '../settings/wallpaper-settings.js'
 import * as clockComponent from '../components/clock-component.js'
 import * as defaultController from '../settings/default-controller.js'
+import * as topsitesComponent from '../components/topsites-component.js'
 import { IsLoading } from '../components/spinner-component.js'
 
 let currentDialog
@@ -26,7 +27,8 @@ const dialogs = [
   {
     id: 'shortcut-settings',
     title: 'Shortcut settings',
-    controller: defaultController
+    controller: defaultController,
+    component: topsitesComponent
   },
   { id: 'credits', title: 'Credits', controller: defaultController }
 ]

--- a/src/js/components/modal-component.js
+++ b/src/js/components/modal-component.js
@@ -24,8 +24,8 @@ const dialogs = [
     component: clockComponent
   },
   {
-    id: 'misc-settings',
-    title: 'Miscellaneous settings',
+    id: 'shortcut-settings',
+    title: 'Shortcut settings',
     controller: defaultController
   },
   { id: 'credits', title: 'Credits', controller: defaultController }

--- a/src/js/components/search-component.js
+++ b/src/js/components/search-component.js
@@ -1,20 +1,9 @@
-import {
-  SelectedSearchEngine as defaultSearchEngine,
-  SetDefaultSettings
-} from '../settings/defaults.js'
-
 let SelectedSearchEngine
 
-export function init () {
-  chrome.storage.local.get(['SelectedSearchEngine'], (result) => {
-    SelectedSearchEngine = result.SelectedSearchEngine
-    if (!SelectedSearchEngine) {
-      SelectedSearchEngine = defaultSearchEngine
-      SetDefaultSettings()
-    }
-    $('#search-dialog-title').text(SelectedSearchEngine.name + ' search...')
-    bindevents()
-  })
+export function init (settings) {
+  SelectedSearchEngine = settings.SelectedSearchEngine
+  $('#search-dialog-title').text(SelectedSearchEngine.name + ' search...')
+  bindevents()
 }
 
 function onSearchButtonClick (e) {

--- a/src/js/components/topsites-component.js
+++ b/src/js/components/topsites-component.js
@@ -7,7 +7,7 @@ import {
   TopsiteOutlines as defaultTopsiteOutlines,
   RetroTitles as defaultRetroTitles,
   SetDefaultSettings
-} from '../settings/defaults'
+} from '../settings/defaults.js'
 
 let TrimTitles
 let TopsiteOutlines

--- a/src/js/components/topsites-component.js
+++ b/src/js/components/topsites-component.js
@@ -2,21 +2,49 @@
  *TODO:
  *Template based DOM elements instead of hacky inline html appends
  */
+import {
+  TrimTitles as defaultTrimTitles,
+  TopsiteOutlines as defaultTopsiteOutlines,
+  RetroTitles as defaultRetroTitles,
+  SetDefaultSettings
+} from '../settings/defaults'
+
+let TrimTitles
+let TopsiteOutlines
+let RetroTitles
 
 export function init () {
   $('.topSiteList').empty()
   // chrome.topSites.get.length = 1 = Firefox
   // chrome.topSites.get.lenght = 0 = Chromium
+  chrome.storage.local.get(
+    ['Trimtitles', 'TopsiteOutlines', 'RetroTitles'],
+    (result) => {
+      TrimTitles = result.TrimTitles
+      TopsiteOutlines = result.TopsiteOutlines
+      RetroTitles = result.RetroTitles
+      if (
+        TrimTitles == null ||
+        TopsiteOutlines == null ||
+        RetroTitles == null
+      ) {
+        TrimTitles = defaultTrimTitles
+        TopsiteOutlines = defaultTopsiteOutlines
+        RetroTitles = defaultRetroTitles
+        SetDefaultSettings()
+      }
 
-  if (chrome.topSites.get.length === 0) {
-    chrome.topSites.get((result) => {
-      buildTopsiteList(result)
-    })
-  } else {
-    chrome.topSites.get({ includeFavicon: true }, (result) => {
-      buildTopsiteList(result)
-    })
-  }
+      if (chrome.topSites.get.length === 0) {
+        chrome.topSites.get((result) => {
+          buildTopsiteList(result)
+        })
+      } else {
+        chrome.topSites.get({ includeFavicon: true }, (result) => {
+          buildTopsiteList(result)
+        })
+      }
+    }
+  )
 }
 
 function buildTopsiteList (sites) {

--- a/src/js/components/topsites-component.js
+++ b/src/js/components/topsites-component.js
@@ -40,7 +40,7 @@ function buildTopsiteList (sites) {
     }
 
     if (TrimTitles) {
-      const trimRegex = /(?<=\)\s|^)([a-zA-z./0-9]*)(?=\s|$)/g
+      const trimRegex = /(?<=\)\s|^)([a-zA-z./0-9]*)(?=:|\s|$)/g
       topSite.title = trimRegex.exec(topSite.title)[0]
     }
     $('.topSiteList').append(

--- a/src/js/components/wallpaper-component.js
+++ b/src/js/components/wallpaper-component.js
@@ -1,26 +1,13 @@
-import {
-  Wallpapers as defaultWallpapers,
-  RandomWallpaper as defaultRandomWallpaper,
-  SetDefaultSettings
-} from '../settings/defaults.js'
-
 let selectedWallpaper
 let Wallpapers
 let RandomWallpaper
 const assetPath = '/assets/img/bg/'
 
-export function init () {
-  chrome.storage.local.get(['Wallpapers', 'RandomWallpaper'], (result) => {
-    Wallpapers = result.Wallpapers
-    RandomWallpaper = result.RandomWallpaper
-    if (!Wallpapers || RandomWallpaper == null) {
-      Wallpapers = defaultWallpapers
-      RandomWallpaper = defaultRandomWallpaper
-      SetDefaultSettings()
-    }
-    selectedWallpaper = selectWallpaper()
-    updateDOM(selectedWallpaper)
-  })
+export function init (settings) {
+  Wallpapers = settings.Wallpapers
+  RandomWallpaper = settings.RandomWallpaper
+  selectedWallpaper = selectWallpaper()
+  updateDOM(selectedWallpaper)
 }
 
 function selectWallpaper () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,14 +5,21 @@ import * as searchComponent from './components/search-component.js'
 import * as clockComponent from './components/clock-component.js'
 import * as modalComponent from './components/modal-component.js'
 import * as startmenuComponent from './components/startmenu-component.js'
+import * as defaultSettings from './settings/defaults.js'
 
 $(function () {
-  clockComponent.init()
-  topsitesComponent.init()
-  searchComponent.init()
-  wallpaperComponent.init()
-  modalComponent.init()
-  startmenuComponent.init()
-  $('.startMenu').hide()
-  $('.speech-bubble').hide()
+  chrome.storage.local.get(defaultSettings.AllSettings, (settings) => {
+    if (Object.values(settings).some((x) => x == null)) {
+      settings = defaultSettings.DefaultSettings
+      defaultSettings.SetDefaultSettings()
+    }
+    clockComponent.init(settings)
+    topsitesComponent.init(settings)
+    searchComponent.init(settings)
+    wallpaperComponent.init(settings)
+    modalComponent.init(settings)
+    startmenuComponent.init()
+    $('.startMenu').hide()
+    $('.speech-bubble').hide()
+  })
 })

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,7 +9,12 @@ import * as defaultSettings from './settings/defaults.js'
 
 $(function () {
   chrome.storage.local.get(defaultSettings.AllSettings, (settings) => {
-    if (Object.values(settings).some((x) => x == null)) {
+    if (
+      JSON.stringify(Object.keys(settings)) !==
+        JSON.stringify(Object.keys(defaultSettings.DefaultSettings)) ||
+      Object.values(settings).some((x) => x == null)
+    ) {
+      console.log('Something went wrong, resetting to defaults...')
       settings = defaultSettings.DefaultSettings
       defaultSettings.SetDefaultSettings()
     }

--- a/src/js/settings/default-controller.js
+++ b/src/js/settings/default-controller.js
@@ -37,7 +37,7 @@ export function save () {
   })
   chrome.storage.local.set(saveData, () => {
     if (_currentDialog.component) {
-      _currentDialog.component.init()
+      _currentDialog.component.init(saveData)
     }
     hideSpinner()
     showSpeechBubble()

--- a/src/js/settings/defaults.js
+++ b/src/js/settings/defaults.js
@@ -23,6 +23,12 @@ export const HourFormat24 = false
 
 export const ShowSeconds = false
 
+export const TrimTitles = false
+
+export const TopsiteOutlines = true
+
+export const RetroTitles = false
+
 export function SetDefaultSettings () {
   chrome.storage.local.clear(() => {
     chrome.storage.local.set({

--- a/src/js/settings/defaults.js
+++ b/src/js/settings/defaults.js
@@ -1,7 +1,7 @@
 import { Wallpaper } from '../models/wallpaper.js'
 import { SearchEngine } from '../models/searchengine.js'
 
-export const Wallpapers = [
+const Wallpapers = [
   new Wallpaper('1.png', true, true, null, 0),
   new Wallpaper('2.png', true, true, null, 1)
 ]
@@ -15,28 +15,40 @@ export const SearchEngineList = [
   new SearchEngine(5, 'Ecosia', 'https://www.ecosia.org/search?q=')
 ]
 
-export const SelectedSearchEngine = SearchEngineList[0]
+const SelectedSearchEngine = SearchEngineList[0]
+const RandomWallpaper = true
+const HourFormat24 = false
+const ShowSeconds = false
+const TrimTitles = false
+const TopsiteOutlines = true
+const RetroTitles = false
 
-export const RandomWallpaper = true
+export const DefaultSettings = {
+  Wallpapers,
+  SelectedSearchEngine,
+  RandomWallpaper,
+  HourFormat24,
+  ShowSeconds,
+  TrimTitles,
+  TopsiteOutlines,
+  RetroTitles
+}
 
-export const HourFormat24 = false
-
-export const ShowSeconds = false
-
-export const TrimTitles = false
-
-export const TopsiteOutlines = true
-
-export const RetroTitles = false
+export const AllSettings = [
+  'Wallpapers',
+  'SelectedSearchEngine',
+  'RandomWallpaper',
+  'HourFormat24',
+  'ShowSeconds',
+  'TrimTitles',
+  'TopsiteOutlines',
+  'RetroTitles'
+]
 
 export function SetDefaultSettings () {
   chrome.storage.local.clear(() => {
     chrome.storage.local.set({
-      Wallpapers,
-      SelectedSearchEngine,
-      RandomWallpaper,
-      HourFormat24,
-      ShowSeconds
+      DefaultSettings
     })
   })
 }

--- a/src/js/settings/defaults.js
+++ b/src/js/settings/defaults.js
@@ -47,8 +47,6 @@ export const AllSettings = [
 
 export function SetDefaultSettings () {
   chrome.storage.local.clear(() => {
-    chrome.storage.local.set({
-      DefaultSettings
-    })
+    chrome.storage.local.set(DefaultSettings)
   })
 }

--- a/src/js/settings/search-settings.js
+++ b/src/js/settings/search-settings.js
@@ -38,7 +38,7 @@ function buildSearchEngineOptionElement (searchEngine) {
 export function save () {
   defaultController.showSpinner('Saving...')
   chrome.storage.local.set({ SelectedSearchEngine }, () => {
-    searchComponent.init()
+    searchComponent.init({ SelectedSearchEngine })
     defaultController.hideSpinner()
     defaultController.showSpeechBubble()
     defaultController.closeModal()

--- a/src/scss/partials/topsites.scss
+++ b/src/scss/partials/topsites.scss
@@ -17,7 +17,6 @@
 .topsite span {
   display: inline-block;
   font-size: 16px;
-  @include stroke(#000, 1px);
   -moz-transform: translate3d(0,0,0);
   -webkit-transform: translate3d(0,0,0);
   padding-left: 1ch;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -265,3 +265,11 @@ input[type='text']:focus {
 #spinner {
   display: none;
 }
+
+.outline {
+  @include stroke(#000, 1px);
+}
+
+.retrobg {
+  background-color: #008080
+}


### PR DESCRIPTION
Added three settings to shortcut/topsite settings:
* Trim titles, trims the titles based on a regex to be more concise
* Enable outlines, shows/hides outline around the shortcut title text
* Retro titles, changes background of shortcut text to be more like windows 95

Fixed an issue regarding defaultsettings not being saved correctly
Changed it so that all settings now get pulled in a single async request to storage, should be more efficient and was causing issues.
